### PR TITLE
change shell to bash in generate_jks.sh

### DIFF
--- a/roles/openshift_logging/files/generate-jks.sh
+++ b/roles/openshift_logging/files/generate-jks.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 set -ex
 
 function usage() {


### PR DESCRIPTION
The generate_jks.sh script uses non-posix standard shell features, this breaks the openshift_logging 
installation if the controller node is running debian or ubuntu.

This problem was not spot before because probably all the developers use fedora or redhat/centos and 
in redhat based distributions the /bin/sh is a symlink to bash. 

Debian and ubuntu adopted dash a long time ago and  in debian/ubuntu controller nodes /bin/sh is a symlink 
to dash, that does not support the extended feature set required by this script. 

This commit changes the shell to bash to ensure it is run with a shell interpreter that supports the extended feature.

https://www.shellcheck.net/
https://wiki.ubuntu.com/DashAsBinSh